### PR TITLE
Voting on FATE TSC Chair

### DIFF
--- a/TSC Board.md
+++ b/TSC Board.md
@@ -6,7 +6,7 @@ responsibilities.
 ## TSC Chair ##
 | Name | Term of office        |
 | ------------ | --------------------- |
-| Qiang Yang      | 2021.XX.XX~2022.XX.XX |
+| Qiang Yang      | 2021.12.10~2022.12.09 |
 
 ## TSC Board ##
 | Board member | Term of office        | Representative | GitHub ID                  |
@@ -15,4 +15,4 @@ responsibilities.
 | ICBC         | 2021.11.11~2023.11.10 | Chuang Zhang   | [RyanSGH](https://github.com/RyanSGH)  |
 | UnionPay     | 2021.11.11~2023.11.10 | Yongkai Zhou   | [vistakk](https://github.com/vistakk)  |
 | VMware       | 2021.11.11~2023.11.10 | Henry Zhang    | [hainingzhang](https://github.com/hainingzhang ) |
-| WeBank       | 2021.11.11~2023.11.10 | Qiang Yang     |                            |
+| WeBank       | 2021.11.11~2023.11.10 | Qiang Yang     |[QiangYang12](quianajiang@webank.com)                            |

--- a/TSC Board.md
+++ b/TSC Board.md
@@ -3,6 +3,11 @@
 [GOVERNANCE.md](./GOVERNANCE.md) describes governance guidelines and the board
 responsibilities.
 
+## TSC Chair ##
+| Name | Term of office        |
+| ------------ | --------------------- |
+| Qiang Yang      | 2021.XX.XX~2022.XX.XX |
+
 ## TSC Board ##
 | Board member | Term of office        | Representative | GitHub ID                  |
 | ------------ | --------------------- | -------------- | -------------------------- |


### PR DESCRIPTION
Qiang Yang has been nominated as FATE TSC Chair at the FATE TSC Board Meeting on Dec, 02 2021. Please view the introduction of the nominee here：
https://github.com/FederatedAI/FATE-Community/blob/master/meeting-minutes/TSC_Board_Meeting/2021-12-02/TSC-Board-Meeting-20211202.pdf

All the TSC members are invited to vote on the nominee for the FATE TSC Chair, Qiang Yang: agree vs. disagree.
Members who have not voted by 23:59 December 14, 2021 will be counted as approval votes by default.

Qiang Yang will become the FATE TSC Chair when 1/2 of TSC members vote for approval.